### PR TITLE
fix(Interaction): use application ID instead of user ID

### DIFF
--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -69,7 +69,7 @@ class InteractionCreateAction extends Action {
 
         const replyRequest = !sentInitialReply
           ? client.api.interactions(interaction.id, interaction.token).callback.post(body)
-          : client.api.webhooks(client.user.id, interaction.token).post(body.data);
+          : client.api.webhooks(client.application.id, interaction.token).post(body.data);
 
         if (!sentInitialReply) sentInitialReply = true;
 
@@ -80,12 +80,12 @@ class InteractionCreateAction extends Action {
         if (!input) {
           throw new Error('Message content or embeds must be provided');
         }
-        await client.api.webhooks(client.user.id, interaction.token).messages(messageId).patch({
+        await client.api.webhooks(client.application.id, interaction.token).messages(messageId).patch({
           data: replyData,
         });
       },
       async delete(messageId = '@original') {
-        await client.api.webhooks(client.user.id, interaction.token).messages(messageId).delete();
+        await client.api.webhooks(client.application.id, interaction.token).messages(messageId).delete();
       },
       async thinking(ephemeral = false) {
         if (sentInitialReply) return;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When replying to messages, you have to use the application's ID instead of the user's ID. I'm unsure how this will effect existing applications, but in my case, this needed to be done. 


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
